### PR TITLE
savegame: save and load current music track and timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased](https://github.com/rr-/Tomb1Main/compare/stable...develop) - ××××-××-××
+- added the current music track and timestamp to the savegame so they now persist on load (#419)
 - fixed Natla's gun moving while she is in her semi death state (#878)
 - fixed an error message from showing on exiting the game when the gym level is not present in the gameflow (#899)
 

--- a/README.md
+++ b/README.md
@@ -366,6 +366,7 @@ Not all options are turned on by default. Refer to `Tomb1Main_ConfigTool.exe` fo
 - added music during the credits
 - added an option to turn off sound effect pitching
 - added an option to use the PlayStation Uzi sound effects
+- added the current music track and timestamp to the savegame so they now persist on load
 - fixed the sound of collecting a secret killing the music
 - fixed audio mixer stopping playing sounds on big explosions
 - fixed game audio not muting when game is minimized

--- a/src/config.c
+++ b/src/config.c
@@ -230,6 +230,7 @@ bool Config_ReadFromJSON(const char *cfg_data)
     READ_BOOL(fix_texture_issues, true);
     READ_BOOL(enable_swing_cancel, true);
     READ_BOOL(enable_tr2_jumping, false);
+    READ_BOOL(load_current_music, true);
 
     CLAMP(g_Config.start_lara_hitpoints, 1, LARA_HITPOINTS);
     CLAMP(g_Config.fov_value, 30, 255);
@@ -413,6 +414,7 @@ bool Config_Write(void)
     WRITE_BOOL(fix_texture_issues);
     WRITE_BOOL(enable_swing_cancel);
     WRITE_BOOL(enable_tr2_jumping);
+    WRITE_BOOL(load_current_music);
 
     // User settings
     WRITE_BOOL(rendering.enable_bilinear_filter);

--- a/src/config.h
+++ b/src/config.h
@@ -110,6 +110,7 @@ typedef struct {
     bool fix_texture_issues;
     bool enable_swing_cancel;
     bool enable_tr2_jumping;
+    bool load_current_music;
 
     struct {
         int32_t layout;

--- a/src/game/game/game.c
+++ b/src/game/game/game.c
@@ -133,6 +133,12 @@ bool Game_Start(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type)
         // reset current info to the defaults so that we do not do
         // Item_GlobalReplace in the inventory initialization routines too early
         Savegame_InitCurrentInfo();
+
+        // prevent audio clipping that occurs when level plays a music track,
+        // and later savegame routines override it while the stream is already
+        // playing in the background thread
+        Music_Pause();
+
         if (!Level_Initialise(level_num)) {
             return false;
         }
@@ -140,6 +146,7 @@ bool Game_Start(int32_t level_num, GAMEFLOW_LEVEL_TYPE level_type)
             LOG_ERROR("Failed to load save file!");
             return false;
         }
+        Music_Unpause();
         break;
 
     case GFL_RESTART:

--- a/src/game/music.c
+++ b/src/game/music.c
@@ -98,8 +98,6 @@ bool Music_Play(int16_t track)
     m_AudioStreamID = S_Audio_StreamSoundCreateFromFile(file_path);
     Memory_FreePointer(&file_path);
 
-    LOG_DEBUG("Playing music on sound_id %d.", m_AudioStreamID);
-
     if (m_AudioStreamID < 0) {
         LOG_ERROR("All music streams are busy");
         return false;

--- a/src/game/music.c
+++ b/src/game/music.c
@@ -98,6 +98,8 @@ bool Music_Play(int16_t track)
     m_AudioStreamID = S_Audio_StreamSoundCreateFromFile(file_path);
     Memory_FreePointer(&file_path);
 
+    LOG_DEBUG("Playing music on sound_id %d.", m_AudioStreamID);
+
     if (m_AudioStreamID < 0) {
         LOG_ERROR("All music streams are busy");
         return false;
@@ -191,4 +193,20 @@ void Music_Unpause(void)
 int16_t Music_CurrentTrack(void)
 {
     return m_Track;
+}
+
+int64_t Music_GetTimestamp(int16_t track)
+{
+    if (m_AudioStreamID < 0) {
+        return -1;
+    }
+    return S_Audio_StreamGetTimestamp(m_AudioStreamID);
+}
+
+bool Music_SeekTimestamp(int16_t track, int64_t timestamp)
+{
+    if (m_AudioStreamID < 0) {
+        return false;
+    }
+    return S_Audio_StreamSeekTimestamp(m_AudioStreamID, timestamp);
 }

--- a/src/game/music.h
+++ b/src/game/music.h
@@ -38,3 +38,9 @@ void Music_Unpause(void);
 // Returns currently playing track. If there is a track playing "over" a looped
 // track, returns the "overriding" track number.
 int16_t Music_CurrentTrack(void);
+
+// Get timestamp of current stream.
+int64_t Music_GetTimestamp(int16_t track);
+
+// Seek to timestamp of current stream.
+bool Music_SeekTimestamp(int16_t track, int64_t timestamp);

--- a/src/game/savegame.h
+++ b/src/game/savegame.h
@@ -20,7 +20,6 @@ typedef enum SAVEGAME_VERSION {
     VERSION_0 = 0,
     VERSION_1 = 1,
     VERSION_2 = 2,
-    VERSION_3 = 3,
 } SAVEGAME_VERSION;
 
 typedef enum SAVEGAME_FORMAT {

--- a/src/game/savegame.h
+++ b/src/game/savegame.h
@@ -13,13 +13,14 @@
 // creatures, triggers etc., and is what actually sets Lara's health, creatures
 // status, triggers, inventory etc.
 
-#define SAVEGAME_CURRENT_VERSION 2
+#define SAVEGAME_CURRENT_VERSION 3
 
 typedef enum SAVEGAME_VERSION {
     VERSION_LEGACY = -1,
     VERSION_0 = 0,
     VERSION_1 = 1,
     VERSION_2 = 2,
+    VERSION_3 = 3,
 } SAVEGAME_VERSION;
 
 typedef enum SAVEGAME_FORMAT {

--- a/src/game/savegame/savegame_bson.c
+++ b/src/game/savegame/savegame_bson.c
@@ -812,16 +812,13 @@ static bool SaveGame_BSON_LoadCurrentMusic(struct json_object_s *music_obj)
     }
 
     int16_t current_track = json_object_get_int(music_obj, "current_track", -1);
-    int32_t timestamp_arr[2];
-    timestamp_arr[0] = json_object_get_int(music_obj, "timestamp1", 0);
-    timestamp_arr[1] = json_object_get_int(music_obj, "timestamp2", 0);
-    int64_t *timestamp = (int64_t *)timestamp_arr;
+    int64_t timestamp = json_object_get_int64(music_obj, "timestamp", -1);
     if (current_track) {
         Music_Play(current_track);
-        if (!Music_SeekTimestamp(current_track, *timestamp)) {
+        if (!Music_SeekTimestamp(current_track, timestamp)) {
             LOG_WARNING(
                 "Could not load current track %d at timestamp %d.",
-                current_track, *timestamp);
+                current_track, timestamp);
         }
     }
 
@@ -1146,9 +1143,7 @@ static struct json_object_s *SaveGame_BSON_DumpCurrentMusic(void)
     if (Music_CurrentTrack()) {
         timestamp = Music_GetTimestamp(Music_CurrentTrack());
     }
-    int32_t *timestamp_arr = (int32_t *)&timestamp;
-    json_object_append_int(current_music_obj, "timestamp1", timestamp_arr[0]);
-    json_object_append_int(current_music_obj, "timestamp2", timestamp_arr[1]);
+    json_object_append_int64(current_music_obj, "timestamp", timestamp);
 
     return current_music_obj;
 }

--- a/src/game/savegame/savegame_bson.c
+++ b/src/game/savegame/savegame_bson.c
@@ -1220,14 +1220,18 @@ bool Savegame_BSON_LoadFromFile(MYFILE *fp, GAME_INFO *game_info)
         goto cleanup;
     }
 
-    int16_t load_track = json_object_get_int(root_obj, "music_track", -1);
+    int16_t music_track = json_object_get_int(root_obj, "music_track", -1);
     int32_t timestamp_arr[2];
     timestamp_arr[0] = json_object_get_int(root_obj, "music_timestamp1", -1);
     timestamp_arr[1] = json_object_get_int(root_obj, "music_timestamp2", -1);
     int64_t *music_timestamp = (int64_t *)timestamp_arr;
-    if (load_track) {
-        Music_Play(load_track);
-        Music_SeekTimestamp(load_track, *music_timestamp);
+    if (music_track) {
+        Music_Play(music_track);
+        if (!Music_SeekTimestamp(music_track, *music_timestamp)) {
+            LOG_WARNING(
+                "Could not load music track %d at timestamp %d.", music_track,
+                *music_timestamp);
+        }
     }
 
     ret = true;

--- a/src/game/savegame/savegame_bson.c
+++ b/src/game/savegame/savegame_bson.c
@@ -1222,7 +1222,7 @@ bool Savegame_BSON_LoadFromFile(MYFILE *fp, GAME_INFO *game_info)
 
     int16_t load_track = json_object_get_int(root_obj, "music_track", -1);
 
-    int32_t timestamp_arr[2];
+    int64_t timestamp_arr[2];
     timestamp_arr[0] = json_object_get_int(root_obj, "music_timestamp1", -1);
     timestamp_arr[1] = json_object_get_int(root_obj, "music_timestamp2", -1);
     LOG_DEBUG("music_timestamp1 %d", timestamp_arr[0]);
@@ -1308,7 +1308,7 @@ void Savegame_BSON_SaveToFile(MYFILE *fp, GAME_INFO *game_info)
     if (save_track) {
         save_timestamp = Music_GetTimestamp(Music_CurrentTrack());
     }
-    int *timestamp_arr = (int *)&save_timestamp;
+    int64_t *timestamp_arr = (int64_t *)&save_timestamp;
     json_object_append_int(root_obj, "music_timestamp1", timestamp_arr[0]);
     json_object_append_int(root_obj, "music_timestamp2", timestamp_arr[1]);
     LOG_DEBUG("music_timestamp1 %d", timestamp_arr[0]);

--- a/src/game/savegame/savegame_bson.c
+++ b/src/game/savegame/savegame_bson.c
@@ -1266,12 +1266,9 @@ bool Savegame_BSON_LoadFromFile(MYFILE *fp, GAME_INFO *game_info)
         goto cleanup;
     }
 
-    if (header.version >= VERSION_3) {
-        struct json_object_s *music_obj =
-            json_object_get_object(root_obj, "music");
-        if (!SaveGame_BSON_LoadCurrentMusic(music_obj)) {
-            goto cleanup;
-        }
+    if (!SaveGame_BSON_LoadCurrentMusic(
+            json_object_get_object(root_obj, "music"))) {
+        goto cleanup;
     }
 
     ret = true;

--- a/src/game/savegame/savegame_bson.c
+++ b/src/game/savegame/savegame_bson.c
@@ -61,6 +61,7 @@ static bool Savegame_BSON_LoadAmmo(
 static bool Savegame_BSON_LoadLOT(struct json_object_s *lot_obj, LOT_INFO *lot);
 static bool Savegame_BSON_LoadLara(
     struct json_object_s *lara_obj, LARA_INFO *lara);
+static bool SaveGame_BSON_LoadCurrentMusic(struct json_object_s *music_obj);
 static struct json_array_s *Savegame_BSON_DumpResumeInfo(
     RESUME_INFO *game_info);
 static struct json_object_s *Savegame_BSON_DumpMisc(GAME_INFO *game_info);
@@ -73,6 +74,7 @@ static struct json_object_s *Savegame_BSON_DumpArm(LARA_ARM *arm);
 static struct json_object_s *Savegame_BSON_DumpAmmo(AMMO_INFO *ammo);
 static struct json_object_s *Savegame_BSON_DumpLOT(LOT_INFO *lot);
 static struct json_object_s *Savegame_BSON_DumpLara(LARA_INFO *lara);
+static struct json_object_s *SaveGame_BSON_DumpCurrentMusic(void);
 
 static void SaveGame_BSON_SaveRaw(
     MYFILE *fp, struct json_value_s *root, int32_t version)
@@ -798,6 +800,34 @@ static bool Savegame_BSON_LoadLara(
     return true;
 }
 
+static bool SaveGame_BSON_LoadCurrentMusic(struct json_object_s *music_obj)
+{
+    if (!g_Config.load_current_music) {
+        return true;
+    }
+
+    if (!music_obj) {
+        LOG_WARNING("Malformed save: invalid or missing current music");
+        return true;
+    }
+
+    int16_t current_track = json_object_get_int(music_obj, "current_track", -1);
+    int32_t timestamp_arr[2];
+    timestamp_arr[0] = json_object_get_int(music_obj, "timestamp1", 0);
+    timestamp_arr[1] = json_object_get_int(music_obj, "timestamp2", 0);
+    int64_t *timestamp = (int64_t *)timestamp_arr;
+    if (current_track) {
+        Music_Play(current_track);
+        if (!Music_SeekTimestamp(current_track, *timestamp)) {
+            LOG_WARNING(
+                "Could not load current track %d at timestamp %d.",
+                current_track, *timestamp);
+        }
+    }
+
+    return true;
+}
+
 static struct json_array_s *Savegame_BSON_DumpResumeInfo(
     RESUME_INFO *resume_info)
 {
@@ -1107,6 +1137,22 @@ static struct json_object_s *Savegame_BSON_DumpLara(LARA_INFO *lara)
     return lara_obj;
 }
 
+static struct json_object_s *SaveGame_BSON_DumpCurrentMusic(void)
+{
+    struct json_object_s *current_music_obj = json_object_new();
+    json_object_append_int(
+        current_music_obj, "current_track", Music_CurrentTrack());
+    int64_t timestamp = 0;
+    if (Music_CurrentTrack()) {
+        timestamp = Music_GetTimestamp(Music_CurrentTrack());
+    }
+    int32_t *timestamp_arr = (int32_t *)&timestamp;
+    json_object_append_int(current_music_obj, "timestamp1", timestamp_arr[0]);
+    json_object_append_int(current_music_obj, "timestamp2", timestamp_arr[1]);
+
+    return current_music_obj;
+}
+
 char *Savegame_BSON_GetSaveFileName(int32_t slot)
 {
     size_t out_size = snprintf(NULL, 0, g_GameFlow.savegame_fmt_bson, slot) + 1;
@@ -1220,17 +1266,10 @@ bool Savegame_BSON_LoadFromFile(MYFILE *fp, GAME_INFO *game_info)
         goto cleanup;
     }
 
-    int16_t music_track = json_object_get_int(root_obj, "music_track", -1);
-    int32_t timestamp_arr[2];
-    timestamp_arr[0] = json_object_get_int(root_obj, "music_timestamp1", -1);
-    timestamp_arr[1] = json_object_get_int(root_obj, "music_timestamp2", -1);
-    int64_t *music_timestamp = (int64_t *)timestamp_arr;
-    if (music_track) {
-        Music_Play(music_track);
-        if (!Music_SeekTimestamp(music_track, *music_timestamp)) {
-            LOG_WARNING(
-                "Could not load music track %d at timestamp %d.", music_track,
-                *music_timestamp);
+    if (header.version >= VERSION_3) {
+        if (!SaveGame_BSON_LoadCurrentMusic(
+                json_object_get_object(root_obj, "music"))) {
+            goto cleanup;
         }
     }
 
@@ -1301,15 +1340,8 @@ void Savegame_BSON_SaveToFile(MYFILE *fp, GAME_INFO *game_info)
     json_object_append_array(root_obj, "fx", SaveGame_BSON_DumpFx());
     json_object_append_object(
         root_obj, "lara", Savegame_BSON_DumpLara(&g_Lara));
-    int16_t music_track = Music_CurrentTrack();
-    json_object_append_int(root_obj, "music_track", music_track);
-    int64_t music_timestamp = 0;
-    if (music_track) {
-        music_timestamp = Music_GetTimestamp(Music_CurrentTrack());
-    }
-    int32_t *timestamp_arr = (int32_t *)&music_timestamp;
-    json_object_append_int(root_obj, "music_timestamp1", timestamp_arr[0]);
-    json_object_append_int(root_obj, "music_timestamp2", timestamp_arr[1]);
+    json_object_append_object(
+        root_obj, "music", SaveGame_BSON_DumpCurrentMusic());
 
     struct json_value_s *root = json_value_from_object(root_obj);
     SaveGame_BSON_SaveRaw(fp, root, SAVEGAME_CURRENT_VERSION);

--- a/src/game/savegame/savegame_bson.c
+++ b/src/game/savegame/savegame_bson.c
@@ -23,7 +23,6 @@
 #include <stdio.h>
 #include <zconf.h>
 #include <zlib.h>
-#include <inttypes.h>
 
 #define SAVEGAME_BSON_MAGIC MKTAG('T', '1', 'M', 'B')
 

--- a/src/game/savegame/savegame_bson.c
+++ b/src/game/savegame/savegame_bson.c
@@ -1229,6 +1229,7 @@ bool Savegame_BSON_LoadFromFile(MYFILE *fp, GAME_INFO *game_info)
     LOG_DEBUG("music_timestamp2 %d", timestamp_arr[1]);
     int64_t load_timestamp = *(int64_t *)timestamp_arr;
     LOG_DEBUG("load_timestamp %d", load_timestamp);
+    LOG_DEBUG("load_track %d", load_track);
 
     if (load_track) {
         Music_Play(load_track);
@@ -1311,8 +1312,10 @@ void Savegame_BSON_SaveToFile(MYFILE *fp, GAME_INFO *game_info)
     int64_t *timestamp_arr = (int64_t *)&save_timestamp;
     json_object_append_int(root_obj, "music_timestamp1", timestamp_arr[0]);
     json_object_append_int(root_obj, "music_timestamp2", timestamp_arr[1]);
+    LOG_DEBUG("save_timestamp %d", save_timestamp);
     LOG_DEBUG("music_timestamp1 %d", timestamp_arr[0]);
     LOG_DEBUG("music_timestamp2 %d", timestamp_arr[1]);
+    LOG_DEBUG("save_track %d", save_track);
 
     struct json_value_s *root = json_value_from_object(root_obj);
     SaveGame_BSON_SaveRaw(fp, root, SAVEGAME_CURRENT_VERSION);

--- a/src/game/savegame/savegame_bson.c
+++ b/src/game/savegame/savegame_bson.c
@@ -1224,8 +1224,8 @@ bool Savegame_BSON_LoadFromFile(MYFILE *fp, GAME_INFO *game_info)
     int16_t load_track = json_object_get_int(root_obj, "music_track", -1);
 
     int32_t timestamp_arr[2];
-    timestamp_arr[0] = json_object_get_int(root_obj, "music_timestamp", -1);
-    timestamp_arr[1] = json_object_get_int(root_obj, "music_timestamp", -1);
+    timestamp_arr[0] = json_object_get_int(root_obj, "music_timestamp1", -1);
+    timestamp_arr[1] = json_object_get_int(root_obj, "music_timestamp2", -1);
     LOG_DEBUG("music_timestamp1 %d", timestamp_arr[0]);
     LOG_DEBUG("music_timestamp2 %d", timestamp_arr[1]);
     int64_t load_timestamp = *(int64_t *)timestamp_arr;
@@ -1311,7 +1311,7 @@ void Savegame_BSON_SaveToFile(MYFILE *fp, GAME_INFO *game_info)
     }
     int *timestamp_arr = (int *)&save_timestamp;
     json_object_append_int(root_obj, "music_timestamp1", timestamp_arr[0]);
-    json_object_append_int(root_obj, "music_timestamp1", timestamp_arr[1]);
+    json_object_append_int(root_obj, "music_timestamp2", timestamp_arr[1]);
     LOG_DEBUG("music_timestamp1 %d", timestamp_arr[0]);
     LOG_DEBUG("music_timestamp2 %d", timestamp_arr[1]);
 

--- a/src/game/savegame/savegame_bson.c
+++ b/src/game/savegame/savegame_bson.c
@@ -1267,8 +1267,9 @@ bool Savegame_BSON_LoadFromFile(MYFILE *fp, GAME_INFO *game_info)
     }
 
     if (header.version >= VERSION_3) {
-        if (!SaveGame_BSON_LoadCurrentMusic(
-                json_object_get_object(root_obj, "music"))) {
+        struct json_object_s *music_obj =
+            json_object_get_object(root_obj, "music");
+        if (!SaveGame_BSON_LoadCurrentMusic(music_obj)) {
             goto cleanup;
         }
     }

--- a/src/game/savegame/savegame_bson.c
+++ b/src/game/savegame/savegame_bson.c
@@ -20,6 +20,7 @@
 #include "util.h"
 
 #include <assert.h>
+#include <inttypes.h>
 #include <stdio.h>
 #include <zconf.h>
 #include <zlib.h>
@@ -817,7 +818,7 @@ static bool SaveGame_BSON_LoadCurrentMusic(struct json_object_s *music_obj)
         Music_Play(current_track);
         if (!Music_SeekTimestamp(current_track, timestamp)) {
             LOG_WARNING(
-                "Could not load current track %d at timestamp %d.",
+                "Could not load current track %d at timestamp %" PRId64 ".",
                 current_track, timestamp);
         }
     }

--- a/src/json/json_base.c
+++ b/src/json/json_base.c
@@ -2,6 +2,7 @@
 
 #include "memory.h"
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -62,6 +63,17 @@ struct json_number_s *json_number_new_int(int number)
     size_t size = snprintf(NULL, 0, "%d", number) + 1;
     char *buf = Memory_Alloc(size);
     sprintf(buf, "%d", number);
+    struct json_number_s *elem = Memory_Alloc(sizeof(struct json_number_s));
+    elem->number = buf;
+    elem->number_size = strlen(buf);
+    return elem;
+}
+
+struct json_number_s *json_number_new_int64(int64_t number)
+{
+    size_t size = snprintf(NULL, 0, "%" PRId64, number) + 1;
+    char *buf = Memory_Alloc(size);
+    sprintf(buf, "%" PRId64, number);
     struct json_number_s *elem = Memory_Alloc(sizeof(struct json_number_s));
     elem->number = buf;
     elem->number_size = strlen(buf);
@@ -317,6 +329,13 @@ void json_object_append_int(
         obj, key, json_value_from_number(json_number_new_int(number)));
 }
 
+void json_object_append_int64(
+    struct json_object_s *obj, const char *key, int64_t number)
+{
+    json_object_append(
+        obj, key, json_value_from_number(json_number_new_int64(number)));
+}
+
 void json_object_append_double(
     struct json_object_s *obj, const char *key, double number)
 {
@@ -398,6 +417,17 @@ int json_object_get_int(struct json_object_s *obj, const char *key, int d)
     struct json_number_s *num = json_value_as_number(value);
     if (num) {
         return atoi(num->number);
+    }
+    return d;
+}
+
+int64_t json_object_get_int64(
+    struct json_object_s *obj, const char *key, int64_t d)
+{
+    struct json_value_s *value = json_object_get_value(obj, key);
+    struct json_number_s *num = json_value_as_number(value);
+    if (num) {
+        return strtoll(num->number, NULL, 10);
     }
     return d;
 }

--- a/src/json/json_base.h
+++ b/src/json/json_base.h
@@ -81,6 +81,7 @@ struct json_value_ex_s {
 
 // numbers
 struct json_number_s *json_number_new_int(int number);
+struct json_number_s *json_number_new_int64(int64_t number);
 struct json_number_s *json_number_new_double(double number);
 void json_number_free(struct json_number_s *num);
 
@@ -126,6 +127,8 @@ void json_object_append(
 void json_object_append_bool(struct json_object_s *obj, const char *key, int b);
 void json_object_append_int(
     struct json_object_s *obj, const char *key, int number);
+void json_object_append_int64(
+    struct json_object_s *obj, const char *key, int64_t number);
 void json_object_append_double(
     struct json_object_s *obj, const char *key, double number);
 void json_object_append_string(
@@ -141,6 +144,8 @@ struct json_value_s *json_object_get_value(
     struct json_object_s *obj, const char *key);
 int json_object_get_bool(struct json_object_s *obj, const char *key, int d);
 int json_object_get_int(struct json_object_s *obj, const char *key, int d);
+int64_t json_object_get_int64(
+    struct json_object_s *obj, const char *key, int64_t d);
 double json_object_get_double(
     struct json_object_s *obj, const char *key, double d);
 const char *json_object_get_string(

--- a/src/specific/s_audio.h
+++ b/src/specific/s_audio.h
@@ -4,6 +4,7 @@
 #include <libavutil/samplefmt.h>
 #include <stdbool.h>
 #include <stddef.h>
+#include <stdint.h>
 
 #define AUDIO_MAX_SAMPLES 1000
 #define AUDIO_MAX_ACTIVE_SAMPLES 50
@@ -38,6 +39,8 @@ bool S_Audio_SampleSoundClose(int sound_id);
 bool S_Audio_SampleSoundCloseAll(void);
 bool S_Audio_SampleSoundSetPan(int sound_id, int pan);
 bool S_Audio_SampleSoundSetVolume(int sound_id, int volume);
+int64_t S_Audio_StreamGetTimestamp(int sound_id);
+bool S_Audio_StreamSeekTimestamp(int sound_id, int64_t timestamp);
 
 #ifdef S_AUDIO_IMPL
     #include <libavformat/avformat.h>

--- a/src/specific/s_audio_stream.c
+++ b/src/specific/s_audio_stream.c
@@ -141,7 +141,6 @@ static bool S_Audio_StreamSoundEnqueueFrame(AUDIO_STREAM_SOUND *stream)
         }
 
         stream->timestamp = stream->av.frame->best_effort_timestamp;
-        LOG_DEBUG("Enqueue timestamp: %d.", stream->timestamp);
         av_frame_unref(stream->av.frame);
     }
 
@@ -531,11 +530,9 @@ int64_t S_Audio_StreamGetTimestamp(int sound_id)
     }
 
     if (m_StreamSounds[sound_id].is_playing) {
-        LOG_DEBUG("Getting timestamp for sound_id %d.", sound_id);
         SDL_LockAudioDevice(g_AudioDeviceID);
         AUDIO_STREAM_SOUND *stream = &m_StreamSounds[sound_id];
         int64_t timestamp = stream->timestamp;
-        LOG_DEBUG("Timestamp: %d.", timestamp);
         SDL_UnlockAudioDevice(g_AudioDeviceID);
         return timestamp;
     }
@@ -551,7 +548,6 @@ bool S_Audio_StreamSeekTimestamp(int sound_id, int64_t timestamp)
     }
 
     if (m_StreamSounds[sound_id].is_playing) {
-        LOG_DEBUG("Seeking timestamp %d on sound_id %d.", timestamp, sound_id);
         SDL_LockAudioDevice(g_AudioDeviceID);
         AUDIO_STREAM_SOUND *stream = &m_StreamSounds[sound_id];
         av_seek_frame(

--- a/src/specific/s_audio_stream.c
+++ b/src/specific/s_audio_stream.c
@@ -288,8 +288,7 @@ static void S_Audio_StreamSoundClear(AUDIO_STREAM_SOUND *stream)
 void S_Audio_StreamSoundInit(void)
 {
     for (int sound_id = 0; sound_id < AUDIO_MAX_ACTIVE_STREAMS; sound_id++) {
-        AUDIO_STREAM_SOUND *stream = &m_StreamSounds[sound_id];
-        S_Audio_StreamSoundClear(stream);
+        S_Audio_StreamSoundClear(&m_StreamSounds[sound_id]);
     }
 }
 

--- a/src/specific/s_audio_stream.c
+++ b/src/specific/s_audio_stream.c
@@ -554,7 +554,7 @@ bool S_Audio_StreamSeekTimestamp(int sound_id, int64_t timestamp)
         LOG_DEBUG("Seeking timestamp %d on sound_id %d.", timestamp, sound_id);
         SDL_LockAudioDevice(g_AudioDeviceID);
         AUDIO_STREAM_SOUND *stream = &m_StreamSounds[sound_id];
-        av_seek_frame(stream->av.format_ctx, -1, timestamp, AVSEEK_FLAG_ANY);
+        av_seek_frame(stream->av.format_ctx, sound_id, timestamp, AVSEEK_FLAG_ANY);
         avcodec_flush_buffers(stream->av.codec_ctx); // ?
         SDL_UnlockAudioDevice(g_AudioDeviceID);
         return true;

--- a/src/specific/s_audio_stream.c
+++ b/src/specific/s_audio_stream.c
@@ -245,6 +245,7 @@ static bool S_Audio_StreamSoundInitialiseFromPath(
     stream->volume = 1.0f;
     stream->timestamp = 0;
     stream->finish_callback = NULL;
+    stream->finish_callback_user_data = NULL;
 
     stream->sdl.stream = SDL_NewAudioStream(
         sdl_format, sdl_channels, sdl_sample_rate, AUDIO_WORKING_FORMAT,
@@ -283,6 +284,7 @@ static void S_Audio_StreamSoundClear(AUDIO_STREAM_SOUND *stream)
     stream->timestamp = 0;
     stream->sdl.stream = NULL;
     stream->finish_callback = NULL;
+    stream->finish_callback_user_data = NULL;
 }
 
 void S_Audio_StreamSoundInit(void)

--- a/src/specific/s_audio_stream.c
+++ b/src/specific/s_audio_stream.c
@@ -554,7 +554,8 @@ bool S_Audio_StreamSeekTimestamp(int sound_id, int64_t timestamp)
         LOG_DEBUG("Seeking timestamp %d on sound_id %d.", timestamp, sound_id);
         SDL_LockAudioDevice(g_AudioDeviceID);
         AUDIO_STREAM_SOUND *stream = &m_StreamSounds[sound_id];
-        av_seek_frame(stream->av.format_ctx, sound_id, timestamp, AVSEEK_FLAG_ANY);
+        av_seek_frame(
+            stream->av.format_ctx, sound_id, timestamp, AVSEEK_FLAG_ANY);
         avcodec_flush_buffers(stream->av.codec_ctx); // ?
         SDL_UnlockAudioDevice(g_AudioDeviceID);
         return true;

--- a/src/specific/s_audio_stream.c
+++ b/src/specific/s_audio_stream.c
@@ -395,13 +395,16 @@ bool S_Audio_StreamSoundClose(int sound_id)
         SDL_FreeAudioStream(stream->sdl.stream);
     }
 
-    if (stream->finish_callback) {
-        stream->finish_callback(sound_id, stream->finish_callback_user_data);
-    }
+    void (*finish_callback)(int, void *) = stream->finish_callback;
+    void *finish_callback_user_data = stream->finish_callback_user_data;
 
     S_Audio_StreamSoundClear(stream);
 
     SDL_UnlockAudioDevice(g_AudioDeviceID);
+
+    if (finish_callback) {
+        finish_callback(sound_id, finish_callback_user_data);
+    }
 
     return true;
 }

--- a/src/specific/s_audio_stream.c
+++ b/src/specific/s_audio_stream.c
@@ -528,8 +528,14 @@ int64_t S_Audio_StreamGetTimestamp(int sound_id)
         LOG_DEBUG("Getting timestamp for sound_id %d.", sound_id);
         SDL_LockAudioDevice(g_AudioDeviceID);
         AUDIO_STREAM_SOUND *stream = &m_StreamSounds[sound_id];
-        return stream->av.frame->best_effort_timestamp;
+        int64_t timestamp = 0;
+        int ret = avcodec_receive_frame(stream->av.codec_ctx, stream->av.frame);
+        if (ret >= 0) {
+            timestamp = stream->av.frame->best_effort_timestamp;
+        }
         SDL_UnlockAudioDevice(g_AudioDeviceID);
+        LOG_DEBUG("Timestamp: %d.", timestamp);
+        return timestamp;
     }
 
     return -1;

--- a/src/specific/s_audio_stream.c
+++ b/src/specific/s_audio_stream.c
@@ -552,7 +552,6 @@ bool S_Audio_StreamSeekTimestamp(int sound_id, int64_t timestamp)
         AUDIO_STREAM_SOUND *stream = &m_StreamSounds[sound_id];
         av_seek_frame(
             stream->av.format_ctx, sound_id, timestamp, AVSEEK_FLAG_ANY);
-        avcodec_flush_buffers(stream->av.codec_ctx); // ?
         SDL_UnlockAudioDevice(g_AudioDeviceID);
         return true;
     }

--- a/tools/config/Tomb1Main_ConfigTool/Resources/Lang/en.json
+++ b/tools/config/Tomb1Main_ConfigTool/Resources/Lang/en.json
@@ -275,6 +275,10 @@
       "Title": "Screenshot format",
       "Description": "Screenshot file format."
     },
+    "load_current_music": {
+      "Title": "Load music track",
+      "Description": "Loads the music track that was playing when the game was saved."
+    },
     "enable_music_in_menu": {
       "Title": "Enable main menu music",
       "Description": "Plays music in the main menu."

--- a/tools/config/Tomb1Main_ConfigTool/Resources/Lang/es.json
+++ b/tools/config/Tomb1Main_ConfigTool/Resources/Lang/es.json
@@ -195,6 +195,10 @@
       "Description": "Permite que los sonidos del juego continúen sonando en la pantalla de inventario.",
       "Title": "Habilitar sonidos de juegos en el inventario"
     },
+    "load_current_music": {
+      "Title": "Load music track",
+      "Description": "TBD."
+    },
     "enable_music_in_menu": {
       "Description": "Reproduce música en el menú principal.",
       "Title": "Habilitar la música del menú principal"

--- a/tools/config/Tomb1Main_ConfigTool/Resources/Lang/es.json
+++ b/tools/config/Tomb1Main_ConfigTool/Resources/Lang/es.json
@@ -197,7 +197,7 @@
     },
     "load_current_music": {
       "Title": "Load music track",
-      "Description": "TBD."
+      "Description": "Carga la pista de música que se estaba reproduciendo cuando se guardó el juego."
     },
     "enable_music_in_menu": {
       "Description": "Reproduce música en el menú principal.",

--- a/tools/config/Tomb1Main_ConfigTool/Resources/Lang/fr.json
+++ b/tools/config/Tomb1Main_ConfigTool/Resources/Lang/fr.json
@@ -275,6 +275,10 @@
       "Title": "Format des screenshots",
       "Description": "Selectionner le format voulu pour les captures d'écran en jeu."
     },
+    "load_current_music": {
+      "Title": "Load music track",
+      "Description": "TBD."
+    },
     "enable_music_in_menu": {
       "Title": "Activer la musique dans le menu principal",
       "Description": "Chosir d'activer ou non la musique dans le menu principal."

--- a/tools/config/Tomb1Main_ConfigTool/Resources/Lang/fr.json
+++ b/tools/config/Tomb1Main_ConfigTool/Resources/Lang/fr.json
@@ -277,7 +277,7 @@
     },
     "load_current_music": {
       "Title": "Load music track",
-      "Description": "TBD."
+      "Description": "Charge la musique qui était en cours de lecture lors de la sauvegarde."
     },
     "enable_music_in_menu": {
       "Title": "Activer la musique dans le menu principal",

--- a/tools/config/Tomb1Main_ConfigTool/Resources/specification.json
+++ b/tools/config/Tomb1Main_ConfigTool/Resources/specification.json
@@ -331,6 +331,11 @@
       "Image": "Graphics/graphic6.jpg",
       "Properties": [
         {
+          "Field": "load_current_music",
+          "DataType": "Bool",
+          "DefaultValue": true
+        },
+        {
           "Field": "enable_music_in_menu",
           "DataType": "Bool",
           "DefaultValue": true


### PR DESCRIPTION
#### Checklist

- [x] I have read the [coding conventions](https://github.com/rr-/Tomb1Main/blob/master/CONTRIBUTING.md#coding-conventions)
- [x] I have added a changelog entry about what my pull request accomplishes

#### Description
Added the current music track and timestamp to the savegame so they now persist on load.